### PR TITLE
URL Cleanup

### DIFF
--- a/package.mk
+++ b/package.mk
@@ -1,5 +1,5 @@
 APP_NAME:=erlang_smtp
 
-UPSTREAM_GIT:=http://github.com/tonyg/erlang-smtp.git
+UPSTREAM_GIT:=https://github.com/tonyg/erlang-smtp.git
 ORIGINAL_APP_FILE=$(CLONE_DIR)/src/$(APP_NAME).app
 DO_NOT_GENERATE_APP_FILE=true


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/tonyg/erlang-smtp.git with 1 occurrences migrated to:  
  https://github.com/tonyg/erlang-smtp.git ([https](https://github.com/tonyg/erlang-smtp.git) result 301).